### PR TITLE
ls990: Update for early-mounted system partition

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -40,7 +40,7 @@ BOARD_USERDATAIMAGE_PARTITION_SIZE := 27325360128
 TARGET_USERIMAGES_USE_F2FS := true
 
 # Recovery
-TARGET_RECOVERY_FSTAB := device/lge/ls990/rootdir/etc/fstab.g3
+TARGET_RECOVERY_FSTAB := device/lge/ls990/rootdir/etc/fstab.recovery
 
 # RIL
 BOARD_GLOBAL_CFLAGS += -DUSE_RIL_VERSION_10

--- a/rootdir/etc/fstab.g3
+++ b/rootdir/etc/fstab.g3
@@ -6,7 +6,6 @@
 # Currently we dont have e2fsck compiled. So fs check would failed.
 
 #<src>                                                <mnt_point>  <type>  <mnt_flags and options>                     <fs_mgr_flags>
-/dev/block/platform/msm_sdcc.1/by-name/system       /system         ext4    ro,barrier=1,noatime                                            wait
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                 wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/encrypt
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue,journal_async_commit      wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/encrypt
 /dev/block/platform/msm_sdcc.1/by-name/cache        /cache          f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                 wait,check,formattable

--- a/rootdir/etc/fstab.recovery
+++ b/rootdir/etc/fstab.recovery
@@ -1,0 +1,25 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+#TODO: Add 'check' as fs_mgr_flags with data partition.
+# Currently we dont have e2fsck compiled. So fs check would failed.
+
+#<src>                                              <mnt_point>     <type>  <mnt_flags and options>                                                                          <fs_mgr_flags>
+/dev/block/platform/msm_sdcc.1/by-name/system       /system         ext4    ro,barrier=1,noatime                                                                             wait
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data           f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                                                  wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/encrypt
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue,journal_async_commit      wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/encrypt
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                                                  wait,check,formattable
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          ext4    noatime,nosuid,nodev,barrier=1,data=ordered,journal_async_commit                                 wait,check,formattable
+/dev/block/platform/msm_sdcc.1/by-name/persist      /persist        ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic                     wait,notrim
+/dev/block/platform/msm_sdcc.1/by-name/boot         /boot           emmc    defaults                                                                                         recoveryonly
+/dev/block/platform/msm_sdcc.1/by-name/recovery     /recovery       emmc    defaults                                                                                         recoveryonly
+/dev/block/platform/msm_sdcc.1/by-name/modem        /firmware       vfat    ro,shortname=lower,uid=1000,gid=1026,dmask=227,fmask=337,context=u:object_r:firmware_file:s0     wait
+/dev/block/platform/msm_sdcc.1/by-name/pad          /misc           emmc    defaults                                                                                         defaults
+
+/dev/block/platform/msm_sdcc.1/by-name/sns          /sns            ext4    nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue                                   wait,notrim
+/dev/block/platform/msm_sdcc.1/by-name/drm          /persist-lg     ext4    nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue                                   wait,notrim
+/dev/block/platform/msm_sdcc.1/by-name/mpt          /mpt            ext4    nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue                                   wait,notrim
+
+/devices/msm_sdcc.3/mmc_host*                       auto            auto    defaults                                                                                         voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/xhci-hcd/usb*                     auto            auto    defaults                                                                                         voldmanaged=usb:auto


### PR DESCRIPTION
 * This removes /system entry from fstab, since this partition
   is now early-mounted and the fstab entry is specified in device tree.

 * At the same time, also include a fully populated fstab, in order to avoid
   build breakage while generating recovery updater scripts.

Change-Id: I8e558458b984e97a45a920c3751a6b7c3f2ebc5c